### PR TITLE
feat: support rankings for AnyLinkableHash, not just EntryHash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1667,7 +1667,7 @@ dependencies = [
 
 [[package]]
 name = "hc_lib_ranking_index"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "hdk 0.1.0-beta-rc.1",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [workspace]
 members = [
+  "lib",
   "example/zomes/example/coordinator",
   "example/zomes/example/integrity",
-  "lib"
 ]
 resolver = "2"
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "hc_lib_ranking_index"
-version = "0.2.0"
+version = "0.3.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -19,8 +19,8 @@ pub struct RankingTag {
 }
 
 #[derive(Serialize, Deserialize, SerializedBytes, Debug, Clone)]
-pub struct EntryHashWithTag {
-    pub entry_hash: EntryHash,
+pub struct HashWithTag {
+    pub hash: AnyLinkableHash,
     pub tag: Option<SerializedBytes>,
 }
 
@@ -29,4 +29,4 @@ pub struct RankingIndex {
     pub index_interval: u64,
 }
 
-pub type EntryRanking = BTreeMap<i64, Vec<EntryHashWithTag>>;
+pub type Ranking = BTreeMap<i64, Vec<HashWithTag>>;


### PR DESCRIPTION
- refactor to support ranking AnyLinkableHash, instead of EntryHash
- renaming functions, traits, and parameters to remove "entry"
- test for linking to ActionHash
- bump version to 0.3.0